### PR TITLE
Implement dynamic path based on .dll location rather than eldenring.exe location

### DIFF
--- a/DiscordRPC/Utils.h
+++ b/DiscordRPC/Utils.h
@@ -10,7 +10,7 @@ namespace Utils
 {
 	static std::ofstream muLogFile;
 
-	static std::string _GetModuleName(bool mainProcessModule)
+	static std::string _GetModulePath(bool mainProcessModule)
 	{
 		HMODULE module = NULL;
 
@@ -20,14 +20,29 @@ namespace Utils
 			GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, &dummyStaticVarToGetModuleHandle, &module);
 		}
 
-		char lpFilename[MAX_PATH];
-		GetModuleFileNameA(module, lpFilename, sizeof(lpFilename));
-		std::string moduleName = strrchr(lpFilename, '\\');
+		char lpFilename[MAX_PATH]; // undefined
+		GetModuleFileNameA(module, lpFilename, MAX_PATH); // absolute\\path\\to\\mod.dll
+		std::string modulePath = lpFilename; // "absolute\\path\\to\\mod.dll" (as a string instead of char arr[])
+
+		return modulePath; // Pulling the raw data and processing it has been separated.
+	}
+
+
+	static std::string _GetModuleName(bool mainProcessModule)
+	{
+		std::string moduleName;
+
+		//modded;
+		//First half of the old _GetModuleName() moved to _GetModulePath().
+		moduleName = _GetModulePath(mainProcessModule); // "absolute\\path\\to\\mod.dll" if mainProcessModule = false. No idea if = true.
+
+		//Second half unchanged
+		moduleName = strrchr(moduleName.c_str(), '\\'); // "mod.dll" (again if mainProcessModule = false, no idea if = true.)
 		moduleName = moduleName.substr(1, moduleName.length());
 
 		if (!mainProcessModule)
 		{
-			moduleName.erase(moduleName.find(".dll"), moduleName.length());
+			moduleName.erase(moduleName.find(".dll"), moduleName.length()); // "mod"
 		}
 
 		return moduleName;
@@ -48,9 +63,17 @@ namespace Utils
 		return currentModName;
 	}
 
+
 	static std::string GetModFolderPath()
 	{
-		return std::string("mods\\" + GetCurrentModName());
+		static std::string modFolderPath = "NULL"; // "NULL" (i.e. runs the below if statement on first call)
+		if (modFolderPath == "NULL")
+		{
+			modFolderPath = _GetModulePath(false); // "absolute\\path\\to\\mod.dll"
+			modFolderPath.erase(modFolderPath.find(".dll"), modFolderPath.length()); // "absolute\\path\\to\\mod"
+		}
+
+		return modFolderPath;
 	}
 
 	static void OpenModLogFile()


### PR DESCRIPTION
Hey just wanted to update this mod to take advantage of Mod Engine 3's features since it otherwise works perfectly and I think it's pretty cool.
Sorry for any mistakes I'm new to Github, C++ and Elden Ring..

Previous path:

```
Eldenring.exe
- Mods
-- DiscordRPC
--- config.ini
```

New path:

```
DiscordRPC.dll
- DiscordRPC
-- config.ini
```


Commit description:

> `GetModFolderPath()` in `utils.h` uses a hardcoded path, `\mods\(modname)\` from eldenring.exe, with this change it now uses `\(modname)\` from the location of the .dll file.
> 
> For Mod Loader and Mod Engine 2 this does not matter and in expected use cases works identically, but Mod Engine 3 allows for injection from an arbitrary directory.
> 
> This will allow users to store configs per-profile and transfer them easily. It also makes installation simpler, by moving the contents of a release .zip into one folder, rather than `\games\mods\` for the `DiscordPRC` folder and their personal mod folder for `DiscordPRC.dll`
> 
> See: [issue](https://redirect.github.com/garyttierney/me3/issues/296)